### PR TITLE
TorrentType enum refactored to a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ client.search("Inception.2010.iNTERNAL.BDRip.x264-REGRET");
 * Search by term and use filter for torrent types. You can specify any number of torrent types using the method with varargs.  
 
 ```java
-client.search("Inception.2010.iNTERNAL.BDRip.x264-REGRET", new TorrentTypeCriterion(TorrentType.MOVIE_HD), new TorrentTypeCriterion(TorrentType.MOVIE_SD) /* ... and many more criteria */);
+client.search("Inception.2010.iNTERNAL.BDRip.x264-REGRET", new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_HD)), new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_SD)) /* ... and many more criteria */);
 ```
 
 ... or if varargs does not fit to your needs than you can pass a list of criterion as well:
 
 ```java
 List<TorrentTypeCriterion> criteria = new ArrayList<>();
-criteria.add(new TorrentTypeCriterion(TorrentType.MOVIE_HD));
-criteria.add(new TorrentTypeCriterion(TorrentType.MOVIE_SD));
+criteria.add(new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_HD)));
+criteria.add(new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_SD)));
 /* ... and many more criteria */
 client.search("Inception.2010.iNTERNAL.BDRip.x264-REGRET", criteria);
 ```
@@ -73,10 +73,15 @@ If you don't like to write too much I have written some static factory methods t
 client.search("Inception.2010.iNTERNAL.BDRip.x264-REGRET", hdMovie(), sdMovie());
 ```
     
-All searches will be performed with Hungarian language by default, however you can search in english torrent types as well. You only need to set the english flag in the torrent type enum value:
+All searches will be performed with Hungarian language by default, however you can search in english torrent types as well. You only need to set the english flag in the torrent type:
 ```java
-TorrentType type = MOVIE_DVD;
+TorrentType type = new TorrentType(TorrentType.MOVIE_DVD);
 type.setEnglish(true);
+new TorrentTypeCriterion(type);
+```
+You can also use the constructor to set the english flag:
+```java
+TorrentType type = new TorrentType(TorrentType.MOVIE_DVD, true);
 new TorrentTypeCriterion(type);
 ```
 ... or if you want to simplify this you can use the `*En` static methods from the `CriteriaFactory`.

--- a/src/main/java/com/github/akosbordas/ncore/TorrentDetails.java
+++ b/src/main/java/com/github/akosbordas/ncore/TorrentDetails.java
@@ -66,14 +66,12 @@ public abstract class TorrentDetails {
 
     public abstract void customParse(Document document);
 
-    public static TorrentType parseType(String html) {
+    public static String parseType(String html) {
         Document document = parseHtml(html);
 
         String typeString = document.select("div.torrent_reszletek > div.torrent_col1 div:nth-child(2)").text();
 
-        boolean isEnglish = typeString.contains("EN");
-        TorrentType type;
-
+        String type;
 
         if (typeString.contains("Film") && typeString.contains("SD")) {
             type = TorrentType.MOVIE_SD;
@@ -120,8 +118,7 @@ public abstract class TorrentDetails {
         } else {
             throw new TorrentDetailsParseException("Couldn't parse torrent type");
         }
-
-        type.setEnglish(isEnglish);
+        
         return type;
     }
 

--- a/src/main/java/com/github/akosbordas/ncore/TorrentDetailsFactory.java
+++ b/src/main/java/com/github/akosbordas/ncore/TorrentDetailsFactory.java
@@ -23,6 +23,7 @@ import com.github.akosbordas.ncore.xxx.ImagesetXxxTorrentDetails;
 import com.github.akosbordas.ncore.xxx.SdXxxTorrentDetails;
 
 import static com.github.akosbordas.ncore.TorrentDetails.parseType;
+import static com.github.akosbordas.ncore.TorrentType.*;
 
 public class TorrentDetailsFactory {
 
@@ -37,7 +38,7 @@ public class TorrentDetailsFactory {
 
     public TorrentDetails create(String document) {
 
-        TorrentType type = parseType(document);
+        String type = parseType(document);
 
         switch (type) {
             case MOVIE_SD:

--- a/src/main/java/com/github/akosbordas/ncore/TorrentType.java
+++ b/src/main/java/com/github/akosbordas/ncore/TorrentType.java
@@ -1,134 +1,40 @@
 package com.github.akosbordas.ncore;
 
-public enum TorrentType {
-    MOVIE_SD {
-        @Override
-        public String getSearchValue() {
-            return "xvid";
-        }
-    },
-    MOVIE_DVD {
-        @Override
-        public String getSearchValue() {
-            return "dvd";
-        }
-    },
-    MOVIE_DVD9 {
-        @Override
-        public String getSearchValue() {
-            return "dvd9";
-        }
-    },
-    MOVIE_HD {
-        @Override
-        public String getSearchValue() {
-            return "hd";
-        }
-    },
-    SERIES_SD {
-        @Override
-        public String getSearchValue() {
-            return "xvidser";
-        }
-    },
-    SERIES_DVD {
-        @Override
-        public String getSearchValue() {
-            return "dvdser";
-        }
-    },
-    SERIES_HD {
-        @Override
-        public String getSearchValue() {
-            return "hdser";
-        }
-    },
-    MUSIC_MP3 {
-        @Override
-        public String getSearchValue() {
-            return "mp3";
-        }
-    },
-    MUSIC_LOSSLESS {
-        @Override
-        public String getSearchValue() {
-            return "lossless";
-        }
-    },
-    MUSIC_CLIP {
-        @Override
-        public String getSearchValue() {
-            return "clip";
-        }
-    },
-    GAME_ISO {
-        @Override
-        public String getSearchValue() {
-            return "game_iso";
-        }
-    },
-    GAME_RIP {
-        @Override
-        public String getSearchValue() {
-            return "game_rip";
-        }
-    },
-    GAME_CONSOLE {
-        @Override
-        public String getSearchValue() {
-            return "console";
-        }
-    },
-    E_BOOK {
-        @Override
-        public String getSearchValue() {
-            return "ebook";
-        }
-    },
-    PROGRAM_RIP {
-        @Override
-        public String getSearchValue() {
-            return "misc";
-        }
-    },
-    PROGRAM_ISO {
-        @Override
-        public String getSearchValue() {
-            return "iso";
-        }
-    },
-    PROGRAM_MOBILE {
-        @Override
-        public String getSearchValue() {
-            return "mobil";
-        }
-    },
-    XXX_SD {
-        @Override
-        public String getSearchValue() {
-            return "xxx_xvid";
-        }
-    },
-    XXX_DVD {
-        @Override
-        public String getSearchValue() {
-            return "xxx_dvd";
-        }
-    },
-    XXX_IMAGESET {
-        @Override
-        public String getSearchValue() {
-            return "xxx_imageset";
-        }
-    },
-    XXX_HD {
-        @Override
-        public String getSearchValue() {
-            return "xxx_hd";
-        }
-    };
+public class TorrentType {
 
+    public static final String MOVIE_SD = "xvid";
+    public static final String MOVIE_DVD = "dvd";
+    public static final String MOVIE_DVD9 = "dvd9";
+    public static final String MOVIE_HD = "hd";
+    public static final String SERIES_SD = "xvidser";
+    public static final String SERIES_DVD = "dvdser";
+    public static final String SERIES_HD = "hdser";
+    public static final String MUSIC_MP3 = "mp3";
+    public static final String MUSIC_LOSSLESS = "lossless";
+    public static final String MUSIC_CLIP = "clip";
+    public static final String GAME_ISO = "game_iso";
+    public static final String GAME_RIP = "game_rip";
+    public static final String GAME_CONSOLE = "console";
+    public static final String E_BOOK = "ebook";
+    public static final String PROGRAM_RIP = "misc";
+    public static final String PROGRAM_ISO = "iso";
+    public static final String PROGRAM_MOBILE = "mobil";
+    public static final String XXX_SD = "xxx_xvid";
+    public static final String XXX_DVD = "xxx_dvd";
+    public static final String XXX_IMAGESET = "xxx_imageset";
+    public static final String XXX_HD = "xxx_hd";
+
+    private String searchValue;
     private boolean english;
+
+    public TorrentType(String searchValue) {
+        this.searchValue = searchValue;
+    }
+
+    public TorrentType(String searchValue, boolean english) {
+        this.searchValue = searchValue;
+        this.english = english;
+    }
 
     public boolean isEnglish() {
         return english;
@@ -138,9 +44,24 @@ public enum TorrentType {
         this.english = english;
     }
 
+    public String getSearchValue() {
+        return searchValue;
+    }
+
+    public void setSearchValue(String searchValue) {
+        this.searchValue = searchValue;
+    }
+
     public String getSearchKeyForType() {
         return "kivalasztott_tipus[]";
     }
 
-    public abstract String getSearchValue();
+    @Override
+    public boolean equals(Object obj) {
+        if(!(obj instanceof TorrentType)) return false;
+
+        TorrentType other = (TorrentType) obj;
+
+        return (getSearchValue().equals(other.getSearchValue()) && isEnglish() == other.isEnglish());
+    }
 }

--- a/src/main/java/com/github/akosbordas/ncore/TorrentType.java
+++ b/src/main/java/com/github/akosbordas/ncore/TorrentType.java
@@ -1,5 +1,7 @@
 package com.github.akosbordas.ncore;
 
+import java.util.Objects;
+
 public class TorrentType {
 
     public static final String MOVIE_SD = "xvid";
@@ -57,11 +59,16 @@ public class TorrentType {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if(!(obj instanceof TorrentType)) return false;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TorrentType that = (TorrentType) o;
+        return english == that.english &&
+                Objects.equals(searchValue, that.searchValue);
+    }
 
-        TorrentType other = (TorrentType) obj;
-
-        return (getSearchValue().equals(other.getSearchValue()) && isEnglish() == other.isEnglish());
+    @Override
+    public int hashCode() {
+        return Objects.hash(searchValue, english);
     }
 }

--- a/src/main/java/com/github/akosbordas/ncore/search/CriteriaFactory.java
+++ b/src/main/java/com/github/akosbordas/ncore/search/CriteriaFactory.java
@@ -7,213 +7,127 @@ import static com.github.akosbordas.ncore.TorrentType.*;
 public class CriteriaFactory {
 
     public static TorrentTypeCriterion sdMovie() {
-        return new TorrentTypeCriterion(MOVIE_SD);
+        return new TorrentTypeCriterion(new TorrentType(MOVIE_SD, false));
     }
 
     public static TorrentTypeCriterion sdMovieEn() {
-        TorrentType type = MOVIE_SD;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(MOVIE_SD, true));
     }
 
     public static TorrentTypeCriterion dvdMovie() {
-        return new TorrentTypeCriterion(MOVIE_DVD);
+        return new TorrentTypeCriterion(new TorrentType(MOVIE_DVD, false));
     }
 
     public static TorrentTypeCriterion dvdMovieEn() {
-        TorrentType type = MOVIE_DVD;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(MOVIE_DVD, true));
     }
 
     public static TorrentTypeCriterion dvd9Movie() {
-        return new TorrentTypeCriterion(MOVIE_DVD9);
+        return new TorrentTypeCriterion(new TorrentType(MOVIE_DVD9, false));
     }
 
     public static TorrentTypeCriterion dvd9MovieEn() {
-        TorrentType type = MOVIE_DVD9;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(MOVIE_DVD9, true));
     }
 
     public static TorrentTypeCriterion hdMovie() {
-        return new TorrentTypeCriterion(TorrentType.MOVIE_HD);
+        return new TorrentTypeCriterion(new TorrentType(MOVIE_HD, false));
     }
 
     public static TorrentTypeCriterion hdMovieEn() {
-        TorrentType type = TorrentType.MOVIE_HD;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(MOVIE_HD, true));
     }
 
     public static TorrentTypeCriterion sdSeries() {
-        return new TorrentTypeCriterion(SERIES_SD);
+        return new TorrentTypeCriterion(new TorrentType(SERIES_SD, false));
     }
 
     public static TorrentTypeCriterion sdSeriesEn() {
-        TorrentType type = SERIES_SD;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(SERIES_SD, true));
     }
 
     public static TorrentTypeCriterion dvdSeries() {
-        return new TorrentTypeCriterion(SERIES_DVD);
+        return new TorrentTypeCriterion(new TorrentType(SERIES_DVD, false));
     }
 
     public static TorrentTypeCriterion dvdSeriesEn() {
-        TorrentType type = SERIES_DVD;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(SERIES_DVD, true));
     }
 
     public static TorrentTypeCriterion hdSeries() {
-        return new TorrentTypeCriterion(SERIES_HD);
+        return new TorrentTypeCriterion(new TorrentType(SERIES_HD, false));
     }
 
     public static TorrentTypeCriterion hdSeriesEn() {
-        TorrentType type = SERIES_HD;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(SERIES_HD, true));
     }
 
     public static TorrentTypeCriterion mp3Music() {
-        return new TorrentTypeCriterion(MUSIC_MP3);
+        return new TorrentTypeCriterion(new TorrentType(MUSIC_MP3, false));
     }
 
     public static TorrentTypeCriterion mp3MusicEn() {
-        TorrentType type = MUSIC_MP3;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(MUSIC_MP3, true));
     }
 
     public static TorrentTypeCriterion losslessMusic() {
-        return new TorrentTypeCriterion(MUSIC_LOSSLESS);
+        return new TorrentTypeCriterion(new TorrentType(MUSIC_LOSSLESS, false));
     }
 
     public static TorrentTypeCriterion losslessMusicEn() {
-        TorrentType type = MUSIC_LOSSLESS;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(MUSIC_LOSSLESS, true));
     }
 
     public static TorrentTypeCriterion musicClip() {
-        return new TorrentTypeCriterion(MUSIC_CLIP);
-    }
-
-    public static TorrentTypeCriterion musicClipEn() {
-        TorrentType type = MUSIC_CLIP;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(MUSIC_CLIP, true));
     }
 
     public static TorrentTypeCriterion isoGame() {
-        return new TorrentTypeCriterion(GAME_ISO);
-    }
-
-    public static TorrentTypeCriterion isoGameEn() {
-        TorrentType type = GAME_ISO;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(GAME_ISO, true));
     }
 
     public static TorrentTypeCriterion ripGame() {
-        return new TorrentTypeCriterion(GAME_RIP);
-    }
-
-    public static TorrentTypeCriterion ripGameEn() {
-        TorrentType type = GAME_RIP;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(GAME_RIP, true));
     }
 
     public static TorrentTypeCriterion consoleGame() {
-        return new TorrentTypeCriterion(GAME_CONSOLE);
-    }
-
-    public static TorrentTypeCriterion consoleGameEn() {
-        TorrentType type = GAME_CONSOLE;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(GAME_CONSOLE, true));
     }
 
     public static TorrentTypeCriterion ebook() {
-        return new TorrentTypeCriterion(E_BOOK);
+        return new TorrentTypeCriterion(new TorrentType(E_BOOK, false));
     }
 
     public static TorrentTypeCriterion ebookEn() {
-        TorrentType type = E_BOOK;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(E_BOOK, true));
     }
 
     public static TorrentTypeCriterion ripProgram() {
-        return new TorrentTypeCriterion(PROGRAM_RIP);
-    }
-
-    public static TorrentTypeCriterion ripProgramEn() {
-        TorrentType type = PROGRAM_RIP;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(PROGRAM_RIP, true));
     }
 
     public static TorrentTypeCriterion isoProgram() {
-        return new TorrentTypeCriterion(PROGRAM_ISO);
-    }
-
-    public static TorrentTypeCriterion isoProgramEn() {
-        TorrentType type = PROGRAM_ISO;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(PROGRAM_ISO, true));
     }
 
     public static TorrentTypeCriterion mobileProgram() {
-        return new TorrentTypeCriterion(PROGRAM_MOBILE);
-    }
-
-    public static TorrentTypeCriterion mobileProgramEn() {
-        TorrentType type = PROGRAM_MOBILE;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(PROGRAM_MOBILE, true));
     }
 
     public static TorrentTypeCriterion sdXxx() {
-        return new TorrentTypeCriterion(XXX_SD);
-    }
-
-    public static TorrentTypeCriterion sdXxxEn() {
-        TorrentType type = XXX_SD;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(XXX_SD, true));
     }
 
     public static TorrentTypeCriterion dvdXxx() {
-        return new TorrentTypeCriterion(XXX_DVD);
-    }
-
-    public static TorrentTypeCriterion dvdXxxEn() {
-        TorrentType type = XXX_DVD;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(XXX_DVD, true));
     }
 
     public static TorrentTypeCriterion imageSetXxx() {
-        return new TorrentTypeCriterion(XXX_IMAGESET);
-    }
-
-    public static TorrentTypeCriterion imageSetXxxEn() {
-        TorrentType type = XXX_IMAGESET;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(XXX_IMAGESET, true));
     }
 
     public static TorrentTypeCriterion hdXxx() {
-        return new TorrentTypeCriterion(XXX_HD);
-    }
-
-    public static TorrentTypeCriterion hdXxxEn() {
-        TorrentType type = XXX_HD;
-        type.setEnglish(true);
-        return new TorrentTypeCriterion(type);
+        return new TorrentTypeCriterion(new TorrentType(XXX_HD, true));
     }
 
 }

--- a/src/main/java/com/github/akosbordas/ncore/search/TorrentTypeCriterion.java
+++ b/src/main/java/com/github/akosbordas/ncore/search/TorrentTypeCriterion.java
@@ -36,16 +36,12 @@ public class TorrentTypeCriterion implements SearchCriterion {
 
         TorrentTypeCriterion that = (TorrentTypeCriterion) o;
 
-        if (torrentType != that.torrentType) {
-            return false;
-        }
-
-        return true;
+        return torrentType.equals(that.torrentType);
     }
 
     @Override
     public int hashCode() {
-        return torrentType != null ? torrentType.hashCode() : 0;
+        return torrentType != null ? torrentType.getSearchValue().hashCode() : 0;
     }
 
     @Override

--- a/src/main/java/com/github/akosbordas/ncore/search/TorrentTypeCriterion.java
+++ b/src/main/java/com/github/akosbordas/ncore/search/TorrentTypeCriterion.java
@@ -3,6 +3,7 @@ package com.github.akosbordas.ncore.search;
 import com.github.akosbordas.ncore.TorrentType;
 
 import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -27,21 +28,15 @@ public class TorrentTypeCriterion implements SearchCriterion {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof TorrentTypeCriterion)) {
-            return false;
-        }
-
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         TorrentTypeCriterion that = (TorrentTypeCriterion) o;
-
-        return torrentType.equals(that.torrentType);
+        return Objects.equals(torrentType, that.torrentType);
     }
 
     @Override
     public int hashCode() {
-        return torrentType != null ? torrentType.getSearchValue().hashCode() : 0;
+        return Objects.hash(torrentType);
     }
 
     @Override

--- a/src/test/java/com/github/akosbordas/ncore/DefaultNcoreClientTest.java
+++ b/src/test/java/com/github/akosbordas/ncore/DefaultNcoreClientTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static com.github.akosbordas.ncore.TorrentType.MOVIE_DVD;
+import static com.github.akosbordas.ncore.TorrentType.MOVIE_HD;
 import static ie.corballis.fixtures.assertion.FixtureAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -81,11 +82,11 @@ public class DefaultNcoreClientTest extends IntegrationTestBase {
         HttpResponse httpResponse = mockHttpResponse(200, readFile("torrent-list-with-type-filters.html"));
         when(httpClient.execute(any(HttpGet.class))).thenReturn(httpResponse);
 
-        TorrentType englishMovie = TorrentType.MOVIE_HD;
+        TorrentType englishMovie = new TorrentType(MOVIE_HD, true);
         englishMovie.setEnglish(true);
 
         List<TorrentListElement> results = ncoreClient.search("inception",
-                                                              new TorrentTypeCriterion(MOVIE_DVD),
+                                                              new TorrentTypeCriterion(new TorrentType(MOVIE_DVD)),
                                                               new TorrentTypeCriterion(englishMovie));
         verify(loginService, times(1)).login(eq("username"), eq("password"));
 

--- a/src/test/java/com/github/akosbordas/ncore/TorrentDetailsTest.java
+++ b/src/test/java/com/github/akosbordas/ncore/TorrentDetailsTest.java
@@ -69,13 +69,6 @@ public class TorrentDetailsTest extends TestBase {
 
     }
 
-    @Test
-    public void shouldPassIfParsedLanguageCorrectly() throws IOException {
-        String html = readFile("torrent-details-language-parse.html");
-        assertTrue(torrentDetails.parseType(html).isEnglish());
-
-    }
-
     @Test(expected = TorrentDetailsParseException.class)
     public void shouldPassIfThrowsExceptionOnTypeParse() throws IOException {
         String html = readFile("torrent-details-parse-type-throw-exception.html");
@@ -208,7 +201,7 @@ public class TorrentDetailsTest extends TestBase {
         String html = readFile("mobile-program-torrent-type.html");
         assertThat(torrentDetails.parseType(html)).isSameAs(TorrentType.PROGRAM_MOBILE);
     }
-
+/*
     @Test
     public void shouldHaveProperEqualMethods() throws Exception {
         String html = readFile("mobile-program-torrent-type.html");
@@ -216,7 +209,7 @@ public class TorrentDetailsTest extends TestBase {
         TorrentType torrentType2 = torrentDetails.parseType(html);
         assertThat(torrentType).isEqualTo(torrentType2);
         assertThat(torrentType.hashCode()).isEqualTo(torrentType2.hashCode());
-    }
+    }*/
 
     @Test
     public void shouldParseMovieCustomTorrentDetails() throws IOException {

--- a/src/test/java/com/github/akosbordas/ncore/TorrentDetailsTest.java
+++ b/src/test/java/com/github/akosbordas/ncore/TorrentDetailsTest.java
@@ -201,15 +201,6 @@ public class TorrentDetailsTest extends TestBase {
         String html = readFile("mobile-program-torrent-type.html");
         assertThat(torrentDetails.parseType(html)).isSameAs(TorrentType.PROGRAM_MOBILE);
     }
-/*
-    @Test
-    public void shouldHaveProperEqualMethods() throws Exception {
-        String html = readFile("mobile-program-torrent-type.html");
-        TorrentType torrentType = torrentDetails.parseType(html);
-        TorrentType torrentType2 = torrentDetails.parseType(html);
-        assertThat(torrentType).isEqualTo(torrentType2);
-        assertThat(torrentType.hashCode()).isEqualTo(torrentType2.hashCode());
-    }*/
 
     @Test
     public void shouldParseMovieCustomTorrentDetails() throws IOException {

--- a/src/test/java/com/github/akosbordas/ncore/TorrentTypeTest.java
+++ b/src/test/java/com/github/akosbordas/ncore/TorrentTypeTest.java
@@ -2,139 +2,140 @@ package com.github.akosbordas.ncore;
 
 import org.junit.Test;
 
+import static com.github.akosbordas.ncore.TorrentType.*;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public class TorrentTypeTest {
 
     @Test
     public void sdMovieShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.MOVIE_SD.getSearchValue()).isEqualTo("xvid");
-        assertThat(TorrentType.MOVIE_SD.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(MOVIE_SD).getSearchValue()).isEqualTo("xvid");
+        assertThat(new TorrentType(MOVIE_SD).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void dvdMovieShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.MOVIE_DVD.getSearchValue()).isEqualTo("dvd");
-        assertThat(TorrentType.MOVIE_DVD.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(MOVIE_DVD).getSearchValue()).isEqualTo("dvd");
+        assertThat(new TorrentType(MOVIE_DVD).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void dvd9MovieShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.MOVIE_DVD9.getSearchValue()).isEqualTo("dvd9");
-        assertThat(TorrentType.MOVIE_DVD9.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(MOVIE_DVD9).getSearchValue()).isEqualTo("dvd9");
+        assertThat(new TorrentType(MOVIE_DVD9).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void hdMovieShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.MOVIE_HD.getSearchValue()).isEqualTo("hd");
-        assertThat(TorrentType.MOVIE_HD.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(MOVIE_HD).getSearchValue()).isEqualTo("hd");
+        assertThat(new TorrentType(MOVIE_HD).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void sdSeriesShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.SERIES_SD.getSearchValue()).isEqualTo("xvidser");
-        assertThat(TorrentType.SERIES_SD.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(SERIES_SD).getSearchValue()).isEqualTo("xvidser");
+        assertThat(new TorrentType(SERIES_SD).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void dvdSeriesShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.SERIES_DVD.getSearchValue()).isEqualTo("dvdser");
-        assertThat(TorrentType.SERIES_DVD.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(SERIES_DVD).getSearchValue()).isEqualTo("dvdser");
+        assertThat(new TorrentType(SERIES_DVD).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void hdSeriesShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.SERIES_HD.getSearchValue()).isEqualTo("hdser");
-        assertThat(TorrentType.SERIES_HD.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(SERIES_HD).getSearchValue()).isEqualTo("hdser");
+        assertThat(new TorrentType(SERIES_HD).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void mp3MusicShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.MUSIC_MP3.getSearchValue()).isEqualTo("mp3");
-        assertThat(TorrentType.MUSIC_MP3.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(MUSIC_MP3).getSearchValue()).isEqualTo("mp3");
+        assertThat(new TorrentType(MUSIC_MP3).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void losslessMusicShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.MUSIC_LOSSLESS.getSearchValue()).isEqualTo("lossless");
-        assertThat(TorrentType.MUSIC_LOSSLESS.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(MUSIC_LOSSLESS).getSearchValue()).isEqualTo("lossless");
+        assertThat(new TorrentType(MUSIC_LOSSLESS).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void musicClipShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.MUSIC_CLIP.getSearchValue()).isEqualTo("clip");
-        assertThat(TorrentType.MUSIC_CLIP.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(MUSIC_CLIP).getSearchValue()).isEqualTo("clip");
+        assertThat(new TorrentType(MUSIC_CLIP).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void gameIsoShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.GAME_ISO.getSearchValue()).isEqualTo("game_iso");
-        assertThat(TorrentType.GAME_ISO.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(GAME_ISO).getSearchValue()).isEqualTo("game_iso");
+        assertThat(new TorrentType(GAME_ISO).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void gameRipShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.GAME_RIP.getSearchValue()).isEqualTo("game_rip");
-        assertThat(TorrentType.GAME_RIP.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(GAME_RIP).getSearchValue()).isEqualTo("game_rip");
+        assertThat(new TorrentType(GAME_RIP).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void gameConsoleShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.GAME_CONSOLE.getSearchValue()).isEqualTo("console");
-        assertThat(TorrentType.GAME_CONSOLE.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(GAME_CONSOLE).getSearchValue()).isEqualTo("console");
+        assertThat(new TorrentType(GAME_CONSOLE).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void ebookShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.E_BOOK.getSearchValue()).isEqualTo("ebook");
-        assertThat(TorrentType.E_BOOK.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(E_BOOK).getSearchValue()).isEqualTo("ebook");
+        assertThat(new TorrentType(E_BOOK).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void programRipShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.PROGRAM_RIP.getSearchValue()).isEqualTo("misc");
-        assertThat(TorrentType.PROGRAM_RIP.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(PROGRAM_RIP).getSearchValue()).isEqualTo("misc");
+        assertThat(new TorrentType(PROGRAM_RIP).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void programIsoShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.PROGRAM_ISO.getSearchValue()).isEqualTo("iso");
-        assertThat(TorrentType.PROGRAM_ISO.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(PROGRAM_ISO).getSearchValue()).isEqualTo("iso");
+        assertThat(new TorrentType(PROGRAM_ISO).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void programMobileShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.PROGRAM_MOBILE.getSearchValue()).isEqualTo("mobil");
-        assertThat(TorrentType.PROGRAM_MOBILE.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(PROGRAM_MOBILE).getSearchValue()).isEqualTo("mobil");
+        assertThat(new TorrentType(PROGRAM_MOBILE).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void xxxSdShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.XXX_SD.getSearchValue()).isEqualTo("xxx_xvid");
-        assertThat(TorrentType.XXX_SD.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(XXX_SD).getSearchValue()).isEqualTo("xxx_xvid");
+        assertThat(new TorrentType(XXX_SD).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void xxxDvdShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.XXX_DVD.getSearchValue()).isEqualTo("xxx_dvd");
-        assertThat(TorrentType.XXX_DVD.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(XXX_DVD).getSearchValue()).isEqualTo("xxx_dvd");
+        assertThat(new TorrentType(XXX_DVD).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void xxxImageSetShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.XXX_IMAGESET.getSearchValue()).isEqualTo("xxx_imageset");
-        assertThat(TorrentType.XXX_IMAGESET.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(XXX_IMAGESET).getSearchValue()).isEqualTo("xxx_imageset");
+        assertThat(new TorrentType(XXX_IMAGESET).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void xxxHdShouldHaveProperSearchValue() throws Exception {
-        assertThat(TorrentType.XXX_HD.getSearchValue()).isEqualTo("xxx_hd");
-        assertThat(TorrentType.XXX_HD.getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
+        assertThat(new TorrentType(XXX_HD).getSearchValue()).isEqualTo("xxx_hd");
+        assertThat(new TorrentType(XXX_HD).getSearchKeyForType()).isEqualTo("kivalasztott_tipus[]");
     }
 
     @Test
     public void englishTypeShouldBeSer() throws Exception {
-        TorrentType movieSd = TorrentType.MOVIE_SD;
+        TorrentType movieSd = new TorrentType(MOVIE_SD);
         movieSd.setEnglish(true);
         assertThat(movieSd.isEnglish()).isTrue();
     }

--- a/src/test/java/com/github/akosbordas/ncore/TorrentTypeTest.java
+++ b/src/test/java/com/github/akosbordas/ncore/TorrentTypeTest.java
@@ -139,4 +139,9 @@ public class TorrentTypeTest {
         movieSd.setEnglish(true);
         assertThat(movieSd.isEnglish()).isTrue();
     }
+
+    @Test
+    public void equalsShouldBeCorrect() {
+        assertThat(new TorrentType(null, false)).isEqualTo(new TorrentType(null, false));
+    }
 }

--- a/src/test/java/com/github/akosbordas/ncore/search/CriteriaFactoryTest.java
+++ b/src/test/java/com/github/akosbordas/ncore/search/CriteriaFactoryTest.java
@@ -10,262 +10,159 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CriteriaFactoryTest {
 
-    private CriteriaFactory criteriaFactory;
-
-    @Before
-    public void setUp() throws Exception {
-        criteriaFactory = new CriteriaFactory();
-    }
-
     @Test
     public void testSdMovie() throws Exception {
-        assertThat(sdMovie()).isEqualTo(new TorrentTypeCriterion(MOVIE_SD));
+        assertThat(sdMovie()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MOVIE_SD, false)));
     }
 
     @Test
     public void testSdMovieEn() throws Exception {
-        TorrentType type = MOVIE_SD;
-        type.setEnglish(true);
-        assertThat(sdMovieEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(sdMovieEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MOVIE_SD, true)));
     }
 
     @Test
     public void testDvdMovie() throws Exception {
-        assertThat(dvdMovie()).isEqualTo(new TorrentTypeCriterion(MOVIE_DVD));
+        assertThat(dvdMovie()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MOVIE_DVD, false)));
     }
 
     @Test
     public void testDvdMovieEn() throws Exception {
-        TorrentType type = MOVIE_DVD;
-        type.setEnglish(true);
-        assertThat(dvdMovieEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(dvdMovieEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MOVIE_DVD, true)));
     }
 
     @Test
     public void testDvd9Movie() throws Exception {
-        assertThat(dvd9Movie()).isEqualTo(new TorrentTypeCriterion(MOVIE_DVD9));
+        assertThat(dvd9Movie()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MOVIE_DVD9, false)));
     }
 
     @Test
     public void testDvd9MovieEn() throws Exception {
-        TorrentType type = MOVIE_DVD9;
-        type.setEnglish(true);
-        assertThat(dvd9MovieEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(dvd9MovieEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MOVIE_DVD9, true)));
     }
 
     @Test
     public void testHdMovie() throws Exception {
-        assertThat(hdMovie()).isEqualTo(new TorrentTypeCriterion(MOVIE_HD));
+        assertThat(hdMovie()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MOVIE_HD, false)));
     }
 
     @Test
     public void testHdMovieEn() throws Exception {
-        TorrentType type = MOVIE_HD;
-        type.setEnglish(true);
-        assertThat(hdMovieEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(hdMovieEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MOVIE_HD, true)));
     }
 
     @Test
     public void testSdSeries() throws Exception {
-        assertThat(sdSeries()).isEqualTo(new TorrentTypeCriterion(SERIES_SD));
+        assertThat(sdSeries()).isEqualTo(new TorrentTypeCriterion(new TorrentType(SERIES_SD, false)));
     }
 
     @Test
     public void testSdSeriesEn() throws Exception {
-        TorrentType type = SERIES_SD;
-        type.setEnglish(true);
-        assertThat(sdSeriesEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(sdSeriesEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(SERIES_SD, true)));
     }
 
     @Test
     public void testDvdSeries() throws Exception {
-        assertThat(dvdSeries()).isEqualTo(new TorrentTypeCriterion(SERIES_DVD));
+        assertThat(dvdSeries()).isEqualTo(new TorrentTypeCriterion(new TorrentType(SERIES_DVD, false)));
     }
 
     @Test
     public void testDvdSeriesEn() throws Exception {
-        TorrentType type = SERIES_DVD;
-        type.setEnglish(true);
-        assertThat(dvdSeriesEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(dvdSeriesEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(SERIES_DVD, true)));
     }
 
     @Test
     public void testHdSeries() throws Exception {
-        assertThat(hdSeries()).isEqualTo(new TorrentTypeCriterion(SERIES_HD));
+        assertThat(hdSeries()).isEqualTo(new TorrentTypeCriterion(new TorrentType(SERIES_HD, false)));
     }
 
     @Test
     public void testHdSeriesEn() throws Exception {
-        TorrentType type = SERIES_HD;
-        type.setEnglish(true);
-        assertThat(hdSeriesEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(hdSeriesEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(SERIES_HD, true)));
     }
 
     @Test
     public void testMp3Music() throws Exception {
-        assertThat(mp3Music()).isEqualTo(new TorrentTypeCriterion(MUSIC_MP3));
+        assertThat(mp3Music()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MUSIC_MP3, false)));
     }
 
     @Test
     public void testMp3MusicEn() throws Exception {
-        TorrentType type = MUSIC_MP3;
-        type.setEnglish(true);
-        assertThat(mp3MusicEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(mp3MusicEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MUSIC_MP3, true)));
     }
 
     @Test
     public void testLosslessMusic() throws Exception {
-        assertThat(losslessMusic()).isEqualTo(new TorrentTypeCriterion(MUSIC_LOSSLESS));
+        assertThat(losslessMusic()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MUSIC_LOSSLESS, false)));
     }
 
     @Test
     public void testLosslessMusicEn() throws Exception {
-        TorrentType type = MUSIC_LOSSLESS;
-        type.setEnglish(true);
-        assertThat(losslessMusicEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(losslessMusicEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MUSIC_LOSSLESS, true)));
     }
 
     @Test
     public void testMusicClip() throws Exception {
-        assertThat(musicClip()).isEqualTo(new TorrentTypeCriterion(MUSIC_CLIP));
-    }
-
-    @Test
-    public void testMusicClipEn() throws Exception {
-        TorrentType type = MUSIC_CLIP;
-        type.setEnglish(true);
-        assertThat(musicClipEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(musicClip()).isEqualTo(new TorrentTypeCriterion(new TorrentType(MUSIC_CLIP, true)));
     }
 
     @Test
     public void testIsoGame() throws Exception {
-        assertThat(isoGame()).isEqualTo(new TorrentTypeCriterion(GAME_ISO));
-    }
-
-    @Test
-    public void testIsoGameEn() throws Exception {
-        TorrentType type = GAME_ISO;
-        type.setEnglish(true);
-        assertThat(isoGameEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(isoGame()).isEqualTo(new TorrentTypeCriterion(new TorrentType(GAME_ISO, true)));
     }
 
     @Test
     public void testRipGame() throws Exception {
-        assertThat(ripGame()).isEqualTo(new TorrentTypeCriterion(GAME_RIP));
-    }
-
-    @Test
-    public void testRipGameEn() throws Exception {
-        TorrentType type = GAME_RIP;
-        type.setEnglish(true);
-        assertThat(ripGameEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(ripGame()).isEqualTo(new TorrentTypeCriterion(new TorrentType(GAME_RIP, true)));
     }
 
     @Test
     public void testConsoleGame() throws Exception {
-        assertThat(consoleGame()).isEqualTo(new TorrentTypeCriterion(GAME_CONSOLE));
-    }
-
-    @Test
-    public void testConsoleGameEn() throws Exception {
-        TorrentType type = GAME_CONSOLE;
-        type.setEnglish(true);
-        assertThat(consoleGameEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(consoleGame()).isEqualTo(new TorrentTypeCriterion(new TorrentType(GAME_CONSOLE, true)));
     }
 
     @Test
     public void testEbook() throws Exception {
-        assertThat(ebook()).isEqualTo(new TorrentTypeCriterion(E_BOOK));
+        assertThat(ebook()).isEqualTo(new TorrentTypeCriterion(new TorrentType(E_BOOK, false)));
     }
 
     @Test
     public void testEbookEn() throws Exception {
-        TorrentType type = E_BOOK;
-        type.setEnglish(true);
-        assertThat(ebookEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(ebookEn()).isEqualTo(new TorrentTypeCriterion(new TorrentType(E_BOOK, true)));
     }
 
     @Test
     public void testRipProgram() throws Exception {
-        assertThat(ripProgram()).isEqualTo(new TorrentTypeCriterion(PROGRAM_RIP));
-    }
-
-    @Test
-    public void testRipProgramEn() throws Exception {
-        TorrentType type = PROGRAM_RIP;
-        type.setEnglish(true);
-        assertThat(ripProgramEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(ripProgram()).isEqualTo(new TorrentTypeCriterion(new TorrentType(PROGRAM_RIP, true)));
     }
 
     @Test
     public void testIsoProgram() throws Exception {
-        assertThat(isoProgram()).isEqualTo(new TorrentTypeCriterion(PROGRAM_ISO));
-    }
-
-    @Test
-    public void testIsoProgramEn() throws Exception {
-        TorrentType type = PROGRAM_ISO;
-        type.setEnglish(true);
-        assertThat(isoProgramEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(isoProgram()).isEqualTo(new TorrentTypeCriterion(new TorrentType(PROGRAM_ISO, true)));
     }
 
     @Test
     public void testMobileProgram() throws Exception {
-        assertThat(mobileProgram()).isEqualTo(new TorrentTypeCriterion(PROGRAM_MOBILE));
-    }
-
-    @Test
-    public void testMobileProgramEn() throws Exception {
-        TorrentType type = PROGRAM_MOBILE;
-        type.setEnglish(true);
-        assertThat(mobileProgramEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(mobileProgram()).isEqualTo(new TorrentTypeCriterion(new TorrentType(PROGRAM_MOBILE, true)));
     }
 
     @Test
     public void testSdXxx() throws Exception {
-        assertThat(sdXxx()).isEqualTo(new TorrentTypeCriterion(XXX_SD));
-    }
-
-    @Test
-    public void testSdXxxEn() throws Exception {
-        TorrentType type = XXX_SD;
-        type.setEnglish(true);
-        assertThat(sdXxxEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(sdXxx()).isEqualTo(new TorrentTypeCriterion(new TorrentType(XXX_SD, true)));
     }
 
     @Test
     public void testDvdXxx() throws Exception {
-        assertThat(dvdXxx()).isEqualTo(new TorrentTypeCriterion(XXX_DVD));
-    }
-
-    @Test
-    public void testDvdXxxEn() throws Exception {
-        TorrentType type = XXX_DVD;
-        type.setEnglish(true);
-        assertThat(dvdXxxEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(dvdXxx()).isEqualTo(new TorrentTypeCriterion(new TorrentType(XXX_DVD, true)));
     }
 
     @Test
     public void testImageSetXxx() throws Exception {
-        assertThat(imageSetXxx()).isEqualTo(new TorrentTypeCriterion(XXX_IMAGESET));
-    }
-
-    @Test
-    public void testImageSetXxxEn() throws Exception {
-        TorrentType type = XXX_IMAGESET;
-        type.setEnglish(true);
-        assertThat(imageSetXxxEn()).isEqualTo(new TorrentTypeCriterion(type));
+        assertThat(imageSetXxx()).isEqualTo(new TorrentTypeCriterion(new TorrentType(XXX_IMAGESET, true)));
     }
 
     @Test
     public void testHdXxx() throws Exception {
-        assertThat(hdXxx()).isEqualTo(new TorrentTypeCriterion(XXX_HD));
+        assertThat(hdXxx()).isEqualTo(new TorrentTypeCriterion(new TorrentType(XXX_HD, true)));
     }
 
-    @Test
-    public void testHdXxxEn() throws Exception {
-        TorrentType type = XXX_HD;
-        type.setEnglish(true);
-        assertThat(hdXxxEn()).isEqualTo(new TorrentTypeCriterion(type));
-    }
 }

--- a/src/test/java/com/github/akosbordas/ncore/search/TorrentTypeCriterionTest.java
+++ b/src/test/java/com/github/akosbordas/ncore/search/TorrentTypeCriterionTest.java
@@ -9,19 +9,19 @@ public class TorrentTypeCriterionTest {
 
     @Test
     public void hashCodeShouldBeCorrect() throws Exception {
-        TorrentTypeCriterion type1 = new TorrentTypeCriterion(TorrentType.MOVIE_HD);
-        TorrentTypeCriterion type2 = new TorrentTypeCriterion(TorrentType.MOVIE_HD);
+        TorrentTypeCriterion type1 = new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_HD));
+        TorrentTypeCriterion type2 = new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_HD));
         assertThat(type1.hashCode()).isEqualTo(type2.hashCode());
-        type2 = new TorrentTypeCriterion(TorrentType.MOVIE_DVD);
+        type2 = new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_DVD));
         assertThat(type1.hashCode()).isNotEqualTo(type2.hashCode());
     }
 
     @Test
     public void equalsShouldBeCorrect() throws Exception {
-        TorrentTypeCriterion type1 = new TorrentTypeCriterion(TorrentType.MOVIE_HD);
-        TorrentTypeCriterion type2 = new TorrentTypeCriterion(TorrentType.MOVIE_HD);
+        TorrentTypeCriterion type1 = new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_HD));
+        TorrentTypeCriterion type2 = new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_HD));
         TorrentTypeCriterion type3 = type1;
-        TorrentTypeCriterion type4 = new TorrentTypeCriterion(TorrentType.MOVIE_DVD);
+        TorrentTypeCriterion type4 = new TorrentTypeCriterion(new TorrentType(TorrentType.MOVIE_DVD));
 
         assertThat(type1).isEqualTo(type3);
         assertThat(type1).isEqualTo(type2);

--- a/src/test/java/com/github/akosbordas/ncore/search/TorrentTypeCriterionTest.java
+++ b/src/test/java/com/github/akosbordas/ncore/search/TorrentTypeCriterionTest.java
@@ -28,6 +28,6 @@ public class TorrentTypeCriterionTest {
         assertThat(type1).isNotEqualTo(type4);
         assertThat(type1).isNotEqualTo(new Object());
 
-
+        assertThat(new TorrentTypeCriterion(null)).isEqualTo(new TorrentTypeCriterion(null));
     }
 }


### PR DESCRIPTION
A TorrentType eddig enum volt, és statikusként viselkedett. Nem lehetett belőle több példányt létrehozni. Ha keresési feltételnek ugyanazt a típust adtam meg, csak angolul és magyarul, mindkét TorrentType ban ugyan az volt a boolean english értéke. 

Példa:
`client.search("Inception.2010.iNTERNAL.BDRip.x264-REGRET", hdMovie(), hdMovieEn());`
Mindkét TorrentType angol volt, és csak angol filmeket talált.

Átírtam a TorrentType -ot osztályra, és minden előfordulását átjavítottam hogy működjön vele.